### PR TITLE
Feature/export result as pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Need help or have questions? We'd love to hear from you!
 - [<img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/twitter.svg" width="16" height="16"> Twitter](https://twitter.com/FutureFund)
 - [<img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/linkedin.svg" width="16" height="16"> LinkedIn](https://linkedin.com/company/FutureFund)
 
-## 🚀 Ready to Start?
+##  Ready to Start?
 
 <div align="center">
   

--- a/assets/script.js
+++ b/assets/script.js
@@ -685,6 +685,64 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 });
 
+document.addEventListener("DOMContentLoaded", () => {
+  const downloadBtn = document.getElementById("downloadPDF");
+  if (downloadBtn) {
+    downloadBtn.addEventListener("click", generatePDF);
+  }
+});
+
+async function generatePDF() {
+  const { jsPDF } = window.jspdf;
+
+  // Select the results section
+  const resultsSection = document.getElementById("results");
+  if (!resultsSection) {
+    showAlert("No results found to export.", "warning");
+    return;
+  }
+
+  try {
+    // Use html2canvas to screenshot results section
+    const canvas = await html2canvas(resultsSection, {
+      scale: 2, // better resolution
+      useCORS: true
+    });
+
+    const imgData = canvas.toDataURL("image/png");
+    const pdf = new jsPDF("p", "mm", "a4");
+
+    // Page dimensions
+    const pageWidth = pdf.internal.pageSize.getWidth();
+    const pageHeight = pdf.internal.pageSize.getHeight();
+
+    // Image dimensions
+    const imgWidth = pageWidth;
+    const imgHeight = (canvas.height * imgWidth) / canvas.width;
+
+    let heightLeft = imgHeight;
+    let position = 0;
+
+    // First page
+    pdf.addImage(imgData, "PNG", 0, position, imgWidth, imgHeight);
+    heightLeft -= pageHeight;
+
+    // If content is larger than one page
+    while (heightLeft > 0) {
+      position = heightLeft - imgHeight;
+      pdf.addPage();
+      pdf.addImage(imgData, "PNG", 0, position, imgWidth, imgHeight);
+      heightLeft -= pageHeight;
+    }
+
+    // Save PDF
+    pdf.save("Retirement_Results.pdf");
+    showAlert("PDF downloaded successfully!", "success");
+  } catch (error) {
+    console.error("PDF generation failed:", error);
+    showAlert("Error generating PDF. Check console for details.", "danger");
+  }
+}
 // Dark mode for navbar
 
 function toggleTheme() {

--- a/calculator.html
+++ b/calculator.html
@@ -231,7 +231,10 @@
           <button id="saveScenario" class="btn btn-outline-primary">
             <i class="fas fa-save me-1"></i> Save Current Scenario
           </button>
-        </div>
+            <button id="downloadPDF" class="btn btn-outline-success">
+              <i class="fas fa-file-pdf me-1"></i> Download Results as PDF
+            </button>
+            </div>
         <div id="scenariosContainer" class="row"></div>
       </section>
       <!-- Important Legal Information -->

--- a/calculator.html
+++ b/calculator.html
@@ -308,6 +308,9 @@
 </footer>
 
     <!-- JavaScript Dependencies -->
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
     <script src="assets/script.js"></script>
   </body>


### PR DESCRIPTION
**###Synopsis**
Adds a feature to export retirement results  as a PDF.  
Uses `html2canvas` + `jsPDF` to screenshot results (including charts + scenarios) and generate a multi-page A4 PDF.

**### Changes**
- Added “Download Results as PDF” button.
- Implemented `generatePDF()` in `script.js`.
- PDF auto-splits into pages if content overflows.

**### Why**
Lets users save/share their retirement projections more easily.

**### Testing**
1. Fill calculator and view results.  
2. Save one or more scenarios.  
3. Click **Download Results as PDF**.  
4. Verify PDF contains totals and the chart as a pdf (multi-page if needed).